### PR TITLE
fix: custom error enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,25 @@ struct MemoryDBConfig;
 impl Database for MemoryDB {
     type Config = MemoryDBConfig;
 
-    fn new(_db_config: MemoryDBConfig) -> Result<Self> {
+    fn new(_db_config: MemoryDBConfig) -> PmtreeResult<Self> {
         Ok(MemoryDB(HashMap::new()))
     }
 
-    fn load(_db_config: MemoryDBConfig) -> Result<Self> {
-        Err(Box::new(Error("Cannot load in-memory DB".to_string())))
+    fn load(_db_config: MemoryDBConfig) -> PmtreeResult<Self> {
+        Err(DatabaseError(DatabaseErrorKind::CannotLoadDatabase))
     }
 
-    fn get(&self, key: DBKey) -> Result<Option<Value>> {
+    fn get(&self, key: DBKey) -> PmtreeResult<Option<Value>> {
         Ok(self.0.get(&key).cloned())
     }
 
-    fn put(&mut self, key: DBKey, value: Value) -> Result<()> {
+    fn put(&mut self, key: DBKey, value: Value) -> PmtreeResult<()> {
         self.0.insert(key, value);
 
         Ok(())
     }
 
-    fn put_batch(&mut self, subtree: HashMap<DBKey, Value>) -> Result<()> {
+    fn put_batch(&mut self, subtree: HashMap<DBKey, Value>) -> PmtreeResult<()> {
         self.0.extend(subtree.into_iter());
 
         Ok(())

--- a/src/database.rs
+++ b/src/database.rs
@@ -8,21 +8,21 @@ pub trait Database {
     type Config: Default;
 
     /// Creates new instance of db
-    fn new(config: Self::Config) -> Result<Self>
+    fn new(config: Self::Config) -> PmtreeResult<Self>
     where
         Self: Sized;
 
     /// Loades existing db (existence check required)
-    fn load(config: Self::Config) -> Result<Self>
+    fn load(config: Self::Config) -> PmtreeResult<Self>
     where
         Self: Sized;
 
     /// Returns value from db by the key
-    fn get(&self, key: DBKey) -> Result<Option<Value>>;
+    fn get(&self, key: DBKey) -> PmtreeResult<Option<Value>>;
 
     /// Puts the value to the db by the key
-    fn put(&mut self, key: DBKey, value: Value) -> Result<()>;
+    fn put(&mut self, key: DBKey, value: Value) -> PmtreeResult<()>;
 
     /// Batc
-    fn put_batch(&mut self, subtree: HashMap<DBKey, Value>) -> Result<()>;
+    fn put_batch(&mut self, subtree: HashMap<DBKey, Value>) -> PmtreeResult<()>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,17 +20,37 @@ pub type DBKey = [u8; 8];
 /// Denotes values in a database
 pub type Value = Vec<u8>;
 
-/// Denotes `Error` type, for handling DB interaction errors
 #[derive(Debug)]
-pub struct Error(pub String);
+pub enum TreeErrorKind {
+    MerkleTreeIsFull,
+    InvalidKey,
+    IndexOutOfBounds,
+}
 
-impl std::fmt::Display for Error {
+#[derive(Debug)]
+pub enum DatabaseErrorKind {
+    CannotLoadDatabase,
+    DatabaseExists,
+}
+
+#[derive(Debug)]
+pub enum PmtreeErrorKind {
+    /// Error in database
+    DatabaseError(DatabaseErrorKind),
+    /// Error in tree
+    TreeError(TreeErrorKind),
+}
+
+impl std::fmt::Display for PmtreeErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        match self {
+            PmtreeErrorKind::DatabaseError(e) => write!(f, "Database error: {e:?}"),
+            PmtreeErrorKind::TreeError(e) => write!(f, "Tree error: {e:?}"),
+        }
     }
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for PmtreeErrorKind {}
 
 /// Custom `Result` type with custom `Error` type
-pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub type PmtreeResult<T> = std::result::Result<T, PmtreeErrorKind>;

--- a/tests/memory_keccak.rs
+++ b/tests/memory_keccak.rs
@@ -17,7 +17,9 @@ impl Database for MemoryDB {
     }
 
     fn load(_db_config: MemoryDBConfig) -> PmtreeResult<Self> {
-        Err(DatabaseError(DatabaseErrorKind::CannotLoadDatabase))
+        Err(PmtreeErrorKind::DatabaseError(
+            DatabaseErrorKind::CannotLoadDatabase,
+        ))
     }
 
     fn get(&self, key: DBKey) -> PmtreeResult<Option<Value>> {

--- a/tests/memory_keccak.rs
+++ b/tests/memory_keccak.rs
@@ -12,25 +12,25 @@ struct MemoryDBConfig;
 impl Database for MemoryDB {
     type Config = MemoryDBConfig;
 
-    fn new(_db_config: MemoryDBConfig) -> Result<Self> {
+    fn new(_db_config: MemoryDBConfig) -> PmtreeResult<Self> {
         Ok(MemoryDB(HashMap::new()))
     }
 
-    fn load(_db_config: MemoryDBConfig) -> Result<Self> {
-        Err(Box::new(Error("Cannot load in-memory DB".to_string())))
+    fn load(_db_config: MemoryDBConfig) -> PmtreeResult<Self> {
+        Err(DatabaseError(DatabaseErrorKind::CannotLoadDatabase))
     }
 
-    fn get(&self, key: DBKey) -> Result<Option<Value>> {
+    fn get(&self, key: DBKey) -> PmtreeResult<Option<Value>> {
         Ok(self.0.get(&key).cloned())
     }
 
-    fn put(&mut self, key: DBKey, value: Value) -> Result<()> {
+    fn put(&mut self, key: DBKey, value: Value) -> PmtreeResult<()> {
         self.0.insert(key, value);
 
         Ok(())
     }
 
-    fn put_batch(&mut self, subtree: HashMap<DBKey, Value>) -> Result<()> {
+    fn put_batch(&mut self, subtree: HashMap<DBKey, Value>) -> PmtreeResult<()> {
         self.0.extend(subtree.into_iter());
 
         Ok(())
@@ -64,7 +64,7 @@ impl Hasher for MyKeccak {
 }
 
 #[test]
-fn insert_delete() -> Result<()> {
+fn insert_delete() -> PmtreeResult<()> {
     let mut mt = MerkleTree::<MemoryDB, MyKeccak>::new(2, MemoryDBConfig)?;
 
     assert_eq!(mt.capacity(), 4);
@@ -110,7 +110,7 @@ fn insert_delete() -> Result<()> {
 }
 
 #[test]
-fn batch_insertions() -> Result<()> {
+fn batch_insertions() -> PmtreeResult<()> {
     let mut mt = MerkleTree::<MemoryDB, MyKeccak>::new(2, MemoryDBConfig)?;
 
     let leaves = [

--- a/tests/poseidon.rs
+++ b/tests/poseidon.rs
@@ -54,7 +54,9 @@ impl Database for MemoryDB {
     }
 
     fn load(_db_config: MemoryDBConfig) -> PmtreeResult<Self> {
-        Err(DatabaseError(DatabaseErrorKind::CannotLoadDatabase))
+        Err(PmtreeErrorKind::DatabaseError(
+            DatabaseErrorKind::CannotLoadDatabase,
+        ))
     }
 
     fn get(&self, key: DBKey) -> PmtreeResult<Option<Value>> {
@@ -85,7 +87,9 @@ impl Database for MySled {
     fn new(db_config: SledConfig) -> PmtreeResult<Self> {
         let db = sled::open(db_config.path).unwrap();
         if db.was_recovered() {
-            return Err(DatabaseError(DatabaseErrorKind::DatabaseExists));
+            return Err(PmtreeErrorKind::DatabaseError(
+                DatabaseErrorKind::DatabaseExists,
+            ));
         }
 
         Ok(MySled(db))
@@ -96,7 +100,9 @@ impl Database for MySled {
 
         if !db.was_recovered() {
             fs::remove_dir_all(&db_config.path).expect("Error removing db");
-            return Err(DatabaseError(DatabaseErrorKind::CannotLoadDatabase));
+            return Err(PmtreeErrorKind::DatabaseError(
+                DatabaseErrorKind::CannotLoadDatabase,
+            ));
         }
 
         Ok(MySled(db))

--- a/tests/sled_keccak.rs
+++ b/tests/sled_keccak.rs
@@ -18,7 +18,9 @@ impl Database for MySled {
     fn new(db_config: SledConfig) -> PmtreeResult<Self> {
         let db = sled::open(db_config.path).unwrap();
         if db.was_recovered() {
-            return Err(DatabaseError(DatabaseErrorKind::DatabaseExists));
+            return Err(PmtreeErrorKind::DatabaseError(
+                DatabaseErrorKind::DatabaseExists,
+            ));
         }
 
         Ok(MySled(db))
@@ -29,7 +31,9 @@ impl Database for MySled {
 
         if !db.was_recovered() {
             fs::remove_dir_all(&db_config.path).expect("Error removing db");
-            return Err(DatabaseError(DatabaseErrorKind::CannotLoadDatabase));
+            return Err(PmtreeErrorKind::DatabaseError(
+                DatabaseErrorKind::CannotLoadDatabase,
+            ));
         }
 
         Ok(MySled(db))

--- a/tests/sled_keccak.rs
+++ b/tests/sled_keccak.rs
@@ -15,33 +15,31 @@ struct SledConfig {
 impl Database for MySled {
     type Config = SledConfig;
 
-    fn new(db_config: SledConfig) -> Result<Self> {
+    fn new(db_config: SledConfig) -> PmtreeResult<Self> {
         let db = sled::open(db_config.path).unwrap();
         if db.was_recovered() {
-            return Err(Box::new(Error("Database exists, try load()!".to_string())));
+            return Err(DatabaseError(DatabaseErrorKind::DatabaseExists));
         }
 
         Ok(MySled(db))
     }
 
-    fn load(db_config: SledConfig) -> Result<Self> {
+    fn load(db_config: SledConfig) -> PmtreeResult<Self> {
         let db = sled::open(&db_config.path).unwrap();
 
         if !db.was_recovered() {
             fs::remove_dir_all(&db_config.path).expect("Error removing db");
-            return Err(Box::new(Error(
-                "Trying to load non-existing database!".to_string(),
-            )));
+            return Err(DatabaseError(DatabaseErrorKind::CannotLoadDatabase));
         }
 
         Ok(MySled(db))
     }
 
-    fn get(&self, key: DBKey) -> Result<Option<Value>> {
+    fn get(&self, key: DBKey) -> PmtreeResult<Option<Value>> {
         Ok(self.0.get(key).unwrap().map(|val| val.to_vec()))
     }
 
-    fn put(&mut self, key: DBKey, value: Value) -> Result<()> {
+    fn put(&mut self, key: DBKey, value: Value) -> PmtreeResult<()> {
         self.0.insert(key, value).unwrap();
 
         self.0.flush().unwrap();
@@ -49,7 +47,7 @@ impl Database for MySled {
         Ok(())
     }
 
-    fn put_batch(&mut self, subtree: HashMap<DBKey, Value>) -> Result<()> {
+    fn put_batch(&mut self, subtree: HashMap<DBKey, Value>) -> PmtreeResult<()> {
         let mut batch = sled::Batch::default();
 
         for (key, value) in subtree {
@@ -89,7 +87,7 @@ impl Hasher for MyKeccak {
 }
 
 #[test]
-fn insert_delete() -> Result<()> {
+fn insert_delete() -> PmtreeResult<()> {
     let mut mt = MerkleTree::<MySled, MyKeccak>::new(
         2,
         SledConfig {
@@ -142,7 +140,7 @@ fn insert_delete() -> Result<()> {
 }
 
 #[test]
-fn batch_insertions() -> Result<()> {
+fn batch_insertions() -> PmtreeResult<()> {
     let mut mt = MerkleTree::<MySled, MyKeccak>::new(
         2,
         SledConfig {


### PR DESCRIPTION
This PR includes custom errors, instead of `Box`ing the errors. This allows the size to be known at compile time.
