### PR TITLE
feat: batch ops

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -231,12 +231,12 @@ where
         let root_key = Key(0, 0);
 
         subtree.insert(root_key, self.root);
-        self.fill_nodes(root_key, start, end, &mut subtree, &leaves, start)?;
-
+        
         for i in to_remove_indices {
             subtree.insert(Key(self.depth, i), H::default_leaf());
         }
-
+        self.fill_nodes(root_key, start, end, &mut subtree, &leaves, start)?;
+        
         let subtree = Arc::new(RwLock::new(subtree));
 
         let root_val = rayon::ThreadPoolBuilder::new()

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -227,7 +227,7 @@ where
         let end = start + leaves.len();
 
         // check if the leaves are in the correct range
-        if leaves.len() + start > self.capacity() {
+        if leaves.len() + start - to_remove_indices.len() > self.capacity() {
             return Err(PmtreeErrorKind::TreeError(TreeErrorKind::IndexOutOfBounds));
         }
 
@@ -238,7 +238,9 @@ where
 
         // check if the indices are unique
         if to_remove_indices.len() != to_remove_indices.iter().collect::<HashSet<_>>().len() {
-            return Err(PmtreeErrorKind::TreeError(TreeErrorKind::CustomError("Indices are not unique".to_string())));
+            return Err(PmtreeErrorKind::TreeError(TreeErrorKind::CustomError(
+                "Indices are not unique".to_string(),
+            )));
         }
 
         let mut subtree = HashMap::<Key, H::Fr>::new();
@@ -246,12 +248,11 @@ where
         let root_key = Key(0, 0);
 
         subtree.insert(root_key, self.root);
-        
+
         self.fill_nodes(root_key, start, end, &mut subtree, &leaves, start)?;
         for i in to_remove_indices {
-            subtree.insert(Key(self.depth, i - leaves.len()), H::default_leaf());
+            subtree.insert(Key(self.depth, i - leaves.len() + 1), H::default_leaf());
         }
-
 
         let subtree = Arc::new(RwLock::new(subtree));
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -251,7 +251,7 @@ where
 
         self.fill_nodes(root_key, start, end, &mut subtree, &leaves, start)?;
         for i in to_remove_indices {
-            subtree.insert(Key(self.depth, i - leaves.len() + 1), H::default_leaf());
+            subtree.insert(Key(self.depth, i + leaves.len()), H::default_leaf());
         }
 
         let subtree = Arc::new(RwLock::new(subtree));

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -252,13 +252,14 @@ where
 
     pub fn batch_operations<I: IntoIterator<Item = H::Fr>, J: IntoIterator<Item = usize>>(
         &mut self,
+        start: Option<usize>,
         leaves: I,
         to_remove_indices: J,
     ) -> PmtreeResult<()> {
         let leaves = leaves.into_iter().collect::<Vec<_>>();
         let to_remove_indices = to_remove_indices.into_iter().collect::<Vec<_>>();
 
-        let start = self.next_index;
+        let start = start.unwrap_or(self.next_index);
         let end = start + leaves.len();
 
         if end - to_remove_indices.len() > self.capacity() {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -250,6 +250,62 @@ where
         Ok(())
     }
 
+    pub fn batch_operations<I: IntoIterator<Item = H::Fr>, J: IntoIterator<Item = usize>>(
+        &mut self,
+        leaves: I,
+        to_remove_indices: J,
+    ) -> PmtreeResult<()> {
+        let leaves = leaves.into_iter().collect::<Vec<_>>();
+        let to_remove_indices = to_remove_indices.into_iter().collect::<Vec<_>>();
+
+        let start = self.next_index;
+        let end = start + leaves.len();
+
+        if end - to_remove_indices.len() > self.capacity() {
+            return Err(PmtreeErrorKind::TreeError(TreeErrorKind::MerkleTreeIsFull));
+        }
+
+        let mut subtree = HashMap::<Key, H::Fr>::new();
+
+        let root_key = Key(0, 0);
+
+        subtree.insert(root_key, self.root);
+        self.fill_nodes(root_key, start, end, &mut subtree, &leaves, start)?;
+
+        for i in to_remove_indices {
+            subtree.insert(Key(self.depth, i), H::default_leaf());
+        }
+
+        let subtree = Arc::new(RwLock::new(subtree));
+
+        let root_val = rayon::ThreadPoolBuilder::new()
+            .num_threads(rayon::current_num_threads())
+            .build()
+            .unwrap()
+            .install(|| Self::batch_recalculate(root_key, Arc::clone(&subtree), self.depth));
+
+        let subtree = RwLock::into_inner(Arc::try_unwrap(subtree).unwrap()).unwrap();
+
+        self.db.put_batch(
+            subtree
+                .into_iter()
+                .map(|(key, value)| (key.into(), H::serialize(value)))
+                .collect(),
+        )?;
+
+        // Update next_index value in db
+        if end > self.next_index {
+            self.next_index = end;
+            self.db
+                .put(NEXT_INDEX_KEY, self.next_index.to_be_bytes().to_vec())?;
+        }
+
+        // Update root value in memory
+        self.root = root_val;
+
+        Ok(())
+    }
+
     // Fills hashmap subtree
     fn fill_nodes(
         &self,

--- a/tests/memory_keccak.rs
+++ b/tests/memory_keccak.rs
@@ -122,7 +122,7 @@ fn batch_insertions() -> PmtreeResult<()> {
         hex!("0000000000000000000000000000000000000000000000000000000000000004"),
     ];
 
-    mt.batch_insert(None, &leaves)?;
+    mt.batch_insert(None, leaves)?;
 
     assert_eq!(
         mt.root(),

--- a/tests/memory_keccak.rs
+++ b/tests/memory_keccak.rs
@@ -151,11 +151,9 @@ fn set_range() -> PmtreeResult<()> {
     Ok(())
 }
 
-
 #[test]
 fn batch_operations() -> PmtreeResult<()> {
     let mut mt = MerkleTree::<MemoryDB, MyKeccak>::new(2, MemoryDBConfig)?;
-
 
     let leaves = [
         hex!("0000000000000000000000000000000000000000000000000000000000000001"),
@@ -186,9 +184,16 @@ fn batch_operations() -> PmtreeResult<()> {
 
     assert_eq!(
         mt.root(),
-        hex!("222ff5e0b5877792c2bc1670e2ccd0c2c97cd7bb1672a57d598db05092d3d72c")
+        hex!("a9bb8c3f1f12e9aa903a50c47f314b57610a3ab32f2d463293f58836def38d36")
     );
 
+    // this should remove the last element
+    mt.batch_operations(None, [], [3])?;
+
+    assert_eq!(
+        mt.root(),
+        hex!("222ff5e0b5877792c2bc1670e2ccd0c2c97cd7bb1672a57d598db05092d3d72c")
+    );
 
     Ok(())
 }

--- a/tests/memory_keccak.rs
+++ b/tests/memory_keccak.rs
@@ -150,3 +150,45 @@ fn set_range() -> PmtreeResult<()> {
 
     Ok(())
 }
+
+
+#[test]
+fn batch_operations() -> PmtreeResult<()> {
+    let mut mt = MerkleTree::<MemoryDB, MyKeccak>::new(2, MemoryDBConfig)?;
+
+
+    let leaves = [
+        hex!("0000000000000000000000000000000000000000000000000000000000000001"),
+        hex!("0000000000000000000000000000000000000000000000000000000000000002"),
+    ];
+
+    mt.batch_insert(None, leaves)?;
+
+    assert_eq!(
+        mt.root(),
+        hex!("893760ec5b5bee236f29e85aef64f17139c3c1b7ff24ce64eb6315fca0f2485b")
+    );
+
+    let leaves = [
+        hex!("0000000000000000000000000000000000000000000000000000000000000003"),
+        hex!("0000000000000000000000000000000000000000000000000000000000000004"),
+    ];
+
+    mt.batch_operations(None, leaves, [])?;
+
+    assert_eq!(
+        mt.root(),
+        hex!("a9bb8c3f1f12e9aa903a50c47f314b57610a3ab32f2d463293f58836def38d36")
+    );
+
+    // this should be a no-op
+    mt.batch_operations(None, [leaves[1]], [3])?;
+
+    assert_eq!(
+        mt.root(),
+        hex!("222ff5e0b5877792c2bc1670e2ccd0c2c97cd7bb1672a57d598db05092d3d72c")
+    );
+
+
+    Ok(())
+}

--- a/tests/sled_keccak.rs
+++ b/tests/sled_keccak.rs
@@ -235,6 +235,14 @@ fn batch_operations() -> PmtreeResult<()> {
 
     assert_eq!(
         mt.root(),
+        hex!("a9bb8c3f1f12e9aa903a50c47f314b57610a3ab32f2d463293f58836def38d36")
+    );
+
+    // this should remove the last element
+    mt.batch_operations(None, [], [3])?;
+
+    assert_eq!(
+        mt.root(),
         hex!("222ff5e0b5877792c2bc1670e2ccd0c2c97cd7bb1672a57d598db05092d3d72c")
     );
 

--- a/tests/sled_keccak.rs
+++ b/tests/sled_keccak.rs
@@ -230,7 +230,8 @@ fn batch_operations() -> PmtreeResult<()> {
         hex!("a9bb8c3f1f12e9aa903a50c47f314b57610a3ab32f2d463293f58836def38d36")
     );
 
-    mt.batch_operations(None, [], [3])?;
+    // this should be a no-op
+    mt.batch_operations(None, [leaves[1]], [3])?;
 
     assert_eq!(
         mt.root(),

--- a/tests/sled_keccak.rs
+++ b/tests/sled_keccak.rs
@@ -223,14 +223,14 @@ fn batch_operations() -> PmtreeResult<()> {
         hex!("0000000000000000000000000000000000000000000000000000000000000004"),
     ];
 
-    mt.batch_operations(leaves, [])?;
+    mt.batch_operations(None, leaves, [])?;
 
     assert_eq!(
         mt.root(),
         hex!("a9bb8c3f1f12e9aa903a50c47f314b57610a3ab32f2d463293f58836def38d36")
     );
 
-    mt.batch_operations([], [0, 1, 2, 3])?;
+    mt.batch_operations(None, [], [0, 1, 2, 3])?;
 
     assert_eq!(
         mt.root(),

--- a/tests/sled_keccak.rs
+++ b/tests/sled_keccak.rs
@@ -230,11 +230,11 @@ fn batch_operations() -> PmtreeResult<()> {
         hex!("a9bb8c3f1f12e9aa903a50c47f314b57610a3ab32f2d463293f58836def38d36")
     );
 
-    mt.batch_operations(None, [], [0, 1, 2, 3])?;
+    mt.batch_operations(None, [], [3])?;
 
     assert_eq!(
         mt.root(),
-        hex!("b4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30")
+        hex!("222ff5e0b5877792c2bc1670e2ccd0c2c97cd7bb1672a57d598db05092d3d72c")
     );
 
     fs::remove_dir_all("batch_operations").expect("Error removing db");

--- a/tests/sled_keccak.rs
+++ b/tests/sled_keccak.rs
@@ -196,3 +196,48 @@ fn set_range() -> PmtreeResult<()> {
 
     Ok(())
 }
+
+#[test]
+fn batch_operations() -> PmtreeResult<()> {
+    let mut mt = MerkleTree::<MySled, MyKeccak>::new(
+        2,
+        SledConfig {
+            path: String::from("batch_operations"),
+        },
+    )?;
+
+    let leaves = [
+        hex!("0000000000000000000000000000000000000000000000000000000000000001"),
+        hex!("0000000000000000000000000000000000000000000000000000000000000002"),
+    ];
+
+    mt.batch_insert(None, &leaves)?;
+
+    assert_eq!(
+        mt.root(),
+        hex!("893760ec5b5bee236f29e85aef64f17139c3c1b7ff24ce64eb6315fca0f2485b")
+    );
+
+    let leaves = [
+        hex!("0000000000000000000000000000000000000000000000000000000000000003"),
+        hex!("0000000000000000000000000000000000000000000000000000000000000004"),
+    ];
+
+    mt.batch_operations(leaves, [])?;
+
+    assert_eq!(
+        mt.root(),
+        hex!("a9bb8c3f1f12e9aa903a50c47f314b57610a3ab32f2d463293f58836def38d36")
+    );
+
+    mt.batch_operations([], [0, 1, 2, 3])?;
+
+    assert_eq!(
+        mt.root(),
+        hex!("b4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30")
+    );
+
+    fs::remove_dir_all("batch_operations").expect("Error removing db");
+
+    Ok(())
+}

--- a/tests/sled_keccak.rs
+++ b/tests/sled_keccak.rs
@@ -159,7 +159,7 @@ fn batch_insertions() -> PmtreeResult<()> {
         hex!("0000000000000000000000000000000000000000000000000000000000000004"),
     ];
 
-    mt.batch_insert(None, &leaves)?;
+    mt.batch_insert(None, leaves)?;
 
     assert_eq!(
         mt.root(),
@@ -211,7 +211,7 @@ fn batch_operations() -> PmtreeResult<()> {
         hex!("0000000000000000000000000000000000000000000000000000000000000002"),
     ];
 
-    mt.batch_insert(None, &leaves)?;
+    mt.batch_insert(None, leaves)?;
 
     assert_eq!(
         mt.root(),


### PR DESCRIPTION
Adds a new fn batch_operations which accepts leaves and indices to remove. it generates a subtree from the input and overrides the existing tree atomically.
