### PR TITLE
fix: make getters to element public

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -16,7 +16,7 @@ const DEFAULT_TREE_DEPTH: usize = 20;
 // Denotes keys (depth, index) in Merkle Tree. Can be converted to DBKey
 // TODO! Think about using hashing for that
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct Key(usize, usize);
+pub struct Key(usize, usize);
 impl From<Key> for DBKey {
     fn from(key: Key) -> Self {
         let cantor_pairing = ((key.0 + key.1) * (key.0 + key.1 + 1) / 2 + key.1) as u64;
@@ -180,7 +180,7 @@ where
     }
 
     // Returns elem by the key
-    fn get_elem(&self, key: Key) -> PmtreeResult<H::Fr> {
+    pub fn get_elem(&self, key: Key) -> PmtreeResult<H::Fr> {
         let res = self
             .db
             .get(key.into())?


### PR DESCRIPTION
Access to intermediate nodes in the tree is required during tree handling . It is not possible to do it directly because the cache is completely private.

Making this function public will solve this problem 

fyi @rymnc 